### PR TITLE
create a newrelic-nozzle uaa client in CF

### DIFF
--- a/add-newrelic-nozzle-uaa-client.yml
+++ b/add-newrelic-nozzle-uaa-client.yml
@@ -1,0 +1,13 @@
+---
+# This ops file add a newrelic-nozzle uaa client which is needed if you deploy the nozzle as a CF app (rather than as a PCF tile)
+# ((newrelic_nozzle_user_password)) must be set as a secret in credhub for this ops file as does the ((system.domain))
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/newrelic-nozzle?
+  value:
+    access-token-validity: 1209600
+    authorized-grant-types: authorization_code,client_credentials,refresh_token
+    redirect-uri: https://uaa.((system_domain))/login
+    override: true
+    secret: ((newrelic_nozzle_user_password))
+    scope: openid,oauth.approvals,doppler.firehose
+    authorities: oauth.login,doppler.firehose


### PR DESCRIPTION
I found that this is required in order to deploy the nozzle as a CF App rather than a PCF tile. I thought it was worth adding this example to show how to satisfy the requirement.