### PR TITLE
fix(.travis): The release tag contains 'v' that is not supported by tile generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,16 @@ jobs:
     - sudo apt-get update
     - go get -u github.com/golang/dep/cmd/dep
     - sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3
+
     - curl -O -L https://github.com/cloudfoundry/bosh-cli/releases/download/v6.2.0/bosh-cli-6.2.0-linux-amd64
     - chmod +x ./bosh-cli-6.2.0-linux-amd64
     - sudo mv ./bosh-cli-6.2.0-linux-amd64 /usr/local/bin/bosh
+
     - curl -O -L https://github.com/cf-platform-eng/tile-generator/releases/download/v14.0.3/tile_linux-64bit
     - chmod +x tile_linux-64bit
     - sudo mv tile_linux-64bit /usr/local/bin/tile
     script:
-    - export RELEASE_TAG=$TRAVIS_TAG
+    - export RELEASE_TAG=${TRAVIS_TAG//v}
     - make release
     deploy:
       provider: releases


### PR DESCRIPTION
The v in the tag name "v0.0.0" is not supported buy `tile build` 