### PR TITLE
[WIP]Handle errors form NewRLPGatewayClient with errorChan

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
 
 [[constraint]]
   name = "github.com/cloudfoundry/go-loggregator"
-  version = "7.7.0"
+  revision = "3b3c7567591d7c217a33a511122fc186a5d8d1f7"
 
 [[constraint]]
   name = "github.com/fatih/camelcase"

--- a/tests/integration/helpers/cfMock.go
+++ b/tests/integration/helpers/cfMock.go
@@ -31,7 +31,6 @@ func (mCF *MockCF) Stop() {
 
 func (mCF *MockCF) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
-	log.Printf("API visited: %s", r.RequestURI)
 
 	switch r.URL.Path {
 	case "/v3/organizations":


### PR DESCRIPTION
Current behavior: The nozzle cannot connect to the API and the Error logs are shown in debug level mode because is wrapped by the api client. 

Expected:The Error type log should be appear showing in a clear way to the user that the client is failing to connect to the api.

An update to the client has been pushed to master to handle this.https://github.com/cloudfoundry/go-loggregator/issues/42