### PR TITLE
fix(insights): check for valid insert key

### DIFF
--- a/newrelic/insights/insights.go
+++ b/newrelic/insights/insights.go
@@ -4,16 +4,23 @@
 package insights
 
 import (
+	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/newrelic/newrelic-pcf-nozzle-tile/app"
+	"github.com/newrelic/newrelic-pcf-nozzle-tile/config"
+	"github.com/newrelic/newrelic-pcf-nozzle-tile/newrelic/attributes"
 
 	"github.com/newrelic/go-insights/client"
 )
 
 var once sync.Once
 var instance *InsertManager
+var cfg = app.Get().Config
 
 // New ...
 func New() *InsertManager {
@@ -47,6 +54,26 @@ func (im *InsertManager) Put(insertKey string, c *client.InsertClient) {
 	im.sync.Unlock()
 }
 
+func checkInsightsKey(c *client.InsertClient) error {
+	logEntry := attributes.NewAttributes()
+	u, _ := url.Parse(cfg.GetString(config.EnvCFAPIRUL))
+	logEntry.SetAttribute("pcf.domain", u.Hostname())
+	logEntry.SetAttribute("agent.version", cfg.GetString("Version"))
+	logEntry.SetAttribute("agent.instance", cfg.GetInt("CF_INSTANCE_INDEX"))
+	logEntry.SetAttribute("agent.ip", cfg.GetString("CF_INSTANCE_IP"))
+	logEntry.SetAttribute("eventType", cfg.GetString(config.NewRelicEventTypeLogMessage))
+	logEntry.SetAttribute("log.timestamp", time.Now().Unix())
+	logEntry.SetAttribute("agent.subscription", cfg.GetString("FIREHOSE_ID"))
+	logEntry.SetAttribute("log.message", "insights heartbeat")
+
+	if err := c.PostEvent(logEntry.Marshal()); err != nil {
+		if strings.Contains(err.Error(), "403") {
+			return fmt.Errorf("invalid insights insert api key: %v", err)
+		}
+	}
+	return nil
+}
+
 // New ...
 func (im *InsertManager) New(insightsInsertKey string, rpmAccountID string, accountRegion string) *client.InsertClient {
 	insertClient := client.NewInsertClient(insightsInsertKey, rpmAccountID)
@@ -54,11 +81,23 @@ func (im *InsertManager) New(insightsInsertKey string, rpmAccountID string, acco
 	insertClient.SetCompression(client.Gzip) //always use compression to Insights
 	if accountRegion == "EU" {
 		//UseCustomURL only sets the host (domain) of the URL
-		insertClient.UseCustomURL(app.Get().Config.GetString("NEWRELIC_EU_BASE_URL"))
+		insertClient.UseCustomURL(cfg.GetString("NEWRELIC_EU_BASE_URL"))
 	}
-	if app.Get().Config.GetString("NEWRELIC_CUSTOM_URL") != "" {
-		insertClient.UseCustomURL(app.Get().Config.GetString("NEWRELIC_CUSTOM_URL"))
+	if cfg.GetString("NEWRELIC_CUSTOM_URL") != "" {
+		insertClient.UseCustomURL(cfg.GetString("NEWRELIC_CUSTOM_URL"))
 	}
+	// a regular check on the insight licence is implemented. If an error related with the key is
+	// returned from insights the nozzle will be stopped.
+	go func(rpm string) {
+		for {
+			if err := checkInsightsKey(insertClient); err != nil {
+				app.Get().Log.Fatalf("fail insights insert client for rpm %s:  %s", rpm, err.Error())
+			}
+			app.Get().Log.Debugf("insights key successfully checked for rpm:%s", rpm)
+			time.Sleep(10 * time.Minute)
+		}
+	}(rpmAccountID)
+
 	insertClient.Start()
 	im.sync.Lock()
 	im.collection[insightsInsertKey] = insertClient

--- a/tests/integration/helpers/insightsMock.go
+++ b/tests/integration/helpers/insightsMock.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 )
 
 type MockInsights struct {
@@ -38,7 +39,12 @@ func (mI *MockInsights) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	rw.WriteHeader(http.StatusOK)
 	rw.Write([]byte(`{"success": true}`))
-	mI.ReceivedContents <- mI.decompress(contents)
+	c := mI.decompress(contents)
+	if strings.Contains(string(c), "insights heartbeat") {
+		//discard hearbet message
+		return
+	}
+	mI.ReceivedContents <- c
 }
 
 func (mI *MockInsights) decompress(src []byte) string {

--- a/tests/integration/nozzle_test.go
+++ b/tests/integration/nozzle_test.go
@@ -379,7 +379,9 @@ ReadingFromInsights:
 		select {
 		case rc := <-m.insights.ReceivedContents:
 			r := make([]map[string]interface{}, 10)
-			json.Unmarshal([]byte(rc), &r)
+			if err := json.Unmarshal([]byte(rc), &r); err != nil {
+				break
+			}
 			for _, rr := range r {
 				et := rr["eventType"].(string)
 				if et == PCFValueMetric || et == PCFContainerMetric || et == PCFCounterEvent {


### PR DESCRIPTION
A check on the license has been added so the nozzle will fail if a not valid insight insert key has been configure or if the license stop from being valid in the future. 