### PR TITLE
fix(cache): race condition

### DIFF
--- a/cfclient/cfapps/cache.go
+++ b/cfclient/cfapps/cache.go
@@ -61,7 +61,10 @@ func (c *Cache) Start() {
 
 			case app := <-c.WriteBuffer:
 				c.sync.Lock()
-				c.Collection[app.GUID] = app
+				if _, ok := c.Collection[app.GUID]; !ok {
+					c.Collection[app.GUID] = app
+					GetInstance().updateAppAsync(app)
+				}
 				c.sync.Unlock()
 			}
 		}

--- a/cfclient/cfapps/manager.go
+++ b/cfclient/cfapps/manager.go
@@ -71,7 +71,6 @@ func (c *CFAppManager) GetApp(guid string) (app *CFApp) {
 	app = NewCFApp(guid)
 	c.app.Log.Debug("Adding new app: ", guid)
 	c.Cache.Put(app)
-	c.updateAppAsync(app)
 	return app
 }
 


### PR DESCRIPTION
### Description
This PR aims to solve a possible race condition leading to multiple APIs call for the same app. 
The solution is to move updateAppAsync where the app is added, since it is executed on a different goroutine is should not add any extra load on that function

The race condition was visible checking the logs and would generate multiple calls to an expensive API:
DEBU[0087] Adding new app: 8f442d6e-d390-4950-aada-292aa4fbbb63
DEBU[0087] Adding new app: 8f442d6e-d390-4950-aada-292aa4fbbb63

After the fix the log could be still be present twice, since I did not want to place the debug log into the lock, the the api will be called only once.

### Analysis of the issue

This is the function that might generate a race condition:
```
// GetApp ...
func (c *CFAppManager) GetApp(guid string) (app *CFApp) {
	var found bool
	if app, found = c.Cache.Get(guid); found {               [1]
		return app
	}
	app = NewCFApp(guid)
	c.app.Log.Debug("Adding new app: ", guid)
	c.Cache.Put(app)                                         [2] Async Put
	c.updateAppAsync(app)                                    [3]
	return app
}
```
If many application comes at the same time with the same ID, they all check [1] and if not present they are added into the collection [2] and then we run the update [3].
The issue is that [2] the put is asynchronous (writes in a channel and wait on a lock) and multiple app with same id can reach [3] and calling the api with the assumption they are the first app reaching that point